### PR TITLE
Update react-swipeable dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-alice-carousel",
-  "version": "1.15.3",
+  "version": "1.15.4",
   "description": "React image gallery, react slideshow carousel, react content rotator",
   "main": "./lib/react-alice-carousel",
   "types": "./lib/types/index.d.ts",
@@ -77,7 +77,7 @@
   },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react-swipeable": "4.3.0"
+    "react-swipeable": "^5.4.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/src/lib/react-alice-carousel.js
+++ b/src/lib/react-alice-carousel.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import Swipeable from 'react-swipeable'
+import { Swipeable } from 'react-swipeable'
 
 import * as Utils from './utils'
 import * as Views from './views'
@@ -451,11 +451,13 @@ export default class AliceCarousel extends React.PureComponent {
     return startPosition - deltaX
   }
 
-  _onTouchMove(e, deltaX, deltaY) {
+  _onTouchMove({ event, deltaX, deltaY }) {
+    event.stopPropagation()
+
     this.swipingStarted = true
     this._handleOnMouseEnter()
 
-    if (Utils.isVerticalTouchMoveDetected(e, deltaX, deltaY)) {
+    if (Utils.isVerticalTouchMoveDetected(event, deltaX, deltaY)) {
       this.verticalSwipingDetected = true
       return
     } else {
@@ -515,7 +517,9 @@ export default class AliceCarousel extends React.PureComponent {
     }
   }
 
-  _onTouchEnd = () => {
+  _onTouchEnd = ({ event }) => {
+    event.stopPropagation()
+
     this.swipingStarted = false
 
     if (this._isSwipeDisable()) {
@@ -695,7 +699,6 @@ export default class AliceCarousel extends React.PureComponent {
       <div className="alice-carousel" ref={this._setRootComponentRef}>
         <Swipeable
           rotationAngle={3}
-          stopPropagation={true}
           onSwiping={this._onTouchMove}
           onSwiped={this._onTouchEnd}
           trackMouse={this.props.mouseDragEnabled}


### PR DESCRIPTION
In my project I use the last version of `react-swipeable` in which there is no default export anymore. Using `react-alice-carousel` with another swipable component causes such an error because of dependency versions conflict:

> Uncaught Invariant Violation: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

This PR includes bumping of `react-swipable` version and small compatibility fixes.