### PR TITLE
Add direction:ltr as the plugin breaks on rtl layout

### DIFF
--- a/src/lib/scss/alice-carousel.scss
+++ b/src/lib/scss/alice-carousel.scss
@@ -12,6 +12,7 @@ $play-btn-size: 32px !default;
   position: relative;
   width: 100%;
   margin: auto;
+  direction: ltr;
 }
 
 .alice-carousel__wrapper {


### PR DESCRIPTION
The plugin breaks on RTL layouts (all the calculations becomes incorrect).

Related to #66 