### PR TITLE
Set transitionTimingFunction to be type of string

### DIFF
--- a/src/lib/types/index.d.ts
+++ b/src/lib/types/index.d.ts
@@ -177,7 +177,7 @@ export interface Props {
    * Default: 'ease-out'
    *
    */
-  transitionTimingFunction?: 'string'
+  transitionTimingFunction?: string
   /**
    * Fired when the event object is changing / returns event object
    */


### PR DESCRIPTION
transitionTimingFunction was set to type of 'string'. I think this was a typo unless it is using new features of typescript for const assertions.