### PR TITLE
debounce-unmount-fix

### DIFF
--- a/src/lib/react-alice-carousel.tsx
+++ b/src/lib/react-alice-carousel.tsx
@@ -34,6 +34,7 @@ export default class AliceCarousel extends React.PureComponent<Props, State> {
 	private startTouchmovePosition: undefined | number;
 	private swipeListener: VS | null = null;
 	private _handleResizeDebounced: () => void | undefined;
+	private _cancelResizeDebounced: () => void | undefined;
 
 	constructor(props) {
 		super(props);
@@ -56,7 +57,7 @@ export default class AliceCarousel extends React.PureComponent<Props, State> {
 		this._handleTouchend = this._handleTouchend.bind(this);
 		this._handleDotClick = this._handleDotClick.bind(this);
 		this._handleResize = this._handleResize.bind(this);
-		this._handleResizeDebounced = Utils.debounce(this._handleResize, 100);
+		[this._handleResizeDebounced, this._cancelResizeDebounced] = Utils.debounce(this._handleResize, 100);
 	}
 
 	async componentDidMount() {
@@ -125,6 +126,7 @@ export default class AliceCarousel extends React.PureComponent<Props, State> {
 	}
 
 	componentWillUnmount() {
+		this._cancelResizeDebounced();
 		this._cancelTimeoutAnimations();
 		this._removeEventListeners();
 	}

--- a/src/lib/utils/timers.ts
+++ b/src/lib/utils/timers.ts
@@ -1,15 +1,18 @@
 export function debounce(func: (...args) => void, ms = 0) {
 	let timer: undefined | number = undefined;
 
-	return function (...args) {
+	const cancel = () => {
 		if (timer) {
 			clearTimeout(timer);
 			timer = undefined;
 		}
+	};
 
+	return [function (...args) {
+		cancel();
 		timer = window.setTimeout(() => {
 			func.apply(this, args);
 			timer = undefined;
 		}, ms);
-	};
+	},  cancel];
 }


### PR DESCRIPTION
This is a changes to fix the issue with unmounting and debounced resize described in this issue
https://github.com/maxmarinich/react-alice-carousel/issues/251

Maybe, the best option would be to refactor the debouce utility to work in an object like way, but I was assuming to leave it in a more fashioned functional way like React framework components usually do.

@maxmarinich What do you think?